### PR TITLE
Feature: Add GraphResultGetRaw

### DIFF
--- a/include/dse.h
+++ b/include/dse.h
@@ -1359,6 +1359,20 @@ dse_graph_result_get_string(const DseGraphResult* result,
                             size_t* length);
 
 /**
+ * Get the raw JSON string from the result.
+ *
+ * @public @memberof DseGraphResult
+ * 
+ * @param[in] result
+ * @param[out] length
+ * @return The raw JSON string.
+ *
+ */
+DSE_EXPORT const char*
+dse_graph_result_get_raw(const DseGraphResult* result,
+                         size_t* length);
+
+/**
  * Return an object as an graph edge.
  *
  * @public @memberof DseGraphResult

--- a/src/graph.cpp
+++ b/src/graph.cpp
@@ -680,6 +680,21 @@ const char* dse_graph_result_get_string(const DseGraphResult* result,
   return result->GetString();
 }
 
+const char* dse_graph_result_get_raw(const DseGraphResult* result,
+                                     size_t* length) {
+  rapidjson::StringBuffer buffer;
+  buffer.Clear();
+
+  rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
+  result->Accept(writer);
+
+  if (length != NULL) {
+    *length = buffer.GetSize();
+  }
+
+  return buffer.GetString();
+}
+
 #define CHECK_FIND_MEMBER(dest, name, expected_index) do { \
   const DseGraphResult* src = find_member(result, name, expected_index); \
   if (src != NULL) { \


### PR DESCRIPTION
GraphResultGetRaw will retrieve the results as a raw json string.
This can be used to pass the JSON in a raw format on to other services.